### PR TITLE
Shell and Date Format Features

### DIFF
--- a/features/ADB.feature
+++ b/features/ADB.feature
@@ -22,3 +22,9 @@ Feature: Using the ADB module
     Given the adb server is started
     And I am connected to the local device
     Then I should be able to uninstall the sample application
+
+  Scenario: Use shell to update the system date
+    Given the adb server is started
+    And I am connected to the local device
+    When I change the devices date and time to 08/10/2012 11:25
+    Then the device time should be Aug 10 11:25:00 EDT 2012

--- a/features/step_definitions/adb_steps.rb
+++ b/features/step_definitions/adb_steps.rb
@@ -32,3 +32,13 @@ Then /^I should be able to uninstall the sample application$/ do
   uninstall 'com.example.android.apis', {:serial => sn}
   last_stdout.should include 'Success'
 end
+
+When /^I change the devices date and time to (.*?)$/ do |date_arg|
+  date = DateTime.strptime(date_arg, '%m/%d/%C%y %I:%M')
+  shell(timeout=60, "date -s #{format_date_for_adb(date)}")
+end
+
+Then /^the device time should be Aug (.*?)$/ do |date_str|
+  last_stdout.should include date_str
+end
+

--- a/lib/ADB.rb
+++ b/lib/ADB.rb
@@ -110,6 +110,26 @@ module ADB
     raise ADBError, "Could not uninstall #{package}" unless stdout_contains "Success"
   end
 
+  #
+  # execute shell command
+  #
+  # @param [varargs] arguments to be passed to the shell command
+  # @param timeout value for the command to complete.  Defaults to 30
+  # seconds.
+  #
+  def shell(timeout=30, *arguments)
+    execute_adb_with(timeout, "wait-for-device shell #{arguments.join}")
+  end
+
+  #
+  # format a date for adb shell date command
+  #
+  # @param date to format.  Defaults current date
+  #
+  def format_date_for_adb(date=Date.new) 
+    date.strftime("%C%y%m%d.%H%M00")
+  end
+
   private
 
   def execute_adb_with(timeout, arguments)

--- a/spec/lib/ADB_spec.rb
+++ b/spec/lib/ADB_spec.rb
@@ -29,6 +29,16 @@ describe ADB do
     ADB.devices
   end
 
+  it "should be able to check the device date and time" do
+    should_call_adb_with('wait-for-device', 'shell', 'date')
+    ADB.shell(timeout=30, 'date')
+  end
+
+  it "should be able to build an date formatted for adb shell date command" do
+    date = DateTime.strptime('04/23/2012  13:24', '%m/%d/%C%y %H:%M')
+    ADB.format_date_for_adb(date).should eq "20120423.132400"
+  end
+
   context "when connecting to a device" do
     before(:each) do
       ADB.should_receive(:last_stdout).and_return("connected to localhost")


### PR DESCRIPTION
Cheezy, 

I've added a new method for passing shell commands thru the adb.  Also added a method to help format a date in a way that is acceptable to the 'adb shell date -s' command, which is useful for overriding the android device's system date (pomodoro timer stuff).  I've got a new scenario and two new unit tests.  Let me know what you think and feel free to push back if you find something that I've missed.

Thanks!
Joel
